### PR TITLE
Add DebugStackLengthLimit to the RecovererLogStack

### DIFF
--- a/middlewares/recoverer.go
+++ b/middlewares/recoverer.go
@@ -265,14 +265,22 @@ func cW(w io.Writer, useColor bool, color []byte, s string, args ...interface{})
 	}
 }
 
-type RecovererLogStack struct{}
+type RecovererLogStack struct {
+	DebugStackLengthLimit int
+}
 
 func (l RecovererLogStack) Parse(ctx context.Context, debugStack []byte, rvr interface{}) ([]byte, error) {
+	debugStackMsgWrapped := strings.Join(strings.Split(string(debugStack), "\n"), "|")
+	if l.DebugStackLengthLimit > 0 {
+		if lenDebugStack := len(debugStackMsgWrapped); lenDebugStack > l.DebugStackLengthLimit {
+			debugStackMsgWrapped = debugStackMsgWrapped[:l.DebugStackLengthLimit]
+		}
+	}
 	parsedLog := log.Parse(ctx, log.ErrorLevelString, "panic happen",
 		fmt.Errorf("panic happen: %v", rvr),
 		log.Field{
 			Key:   "debug_stack",
-			Value: strings.Join(strings.Split(string(debugStack), "\n"), "|"),
+			Value: debugStackMsgWrapped,
 		})
 	return []byte(parsedLog), nil
 }


### PR DESCRIPTION
In some cases log aggregators limit the value length. The only risky part of this `log.Parse` function is the debug stack which can be extremely long. So  I want to give the opportunity to the user to configure the max length of this field.